### PR TITLE
Authenticated Orders methods

### DIFF
--- a/src/Wootrade.Tests/Integrated/WootradeAuthenticatedMethodsSuite.cs
+++ b/src/Wootrade.Tests/Integrated/WootradeAuthenticatedMethodsSuite.cs
@@ -10,6 +10,7 @@ namespace Wootrade.Tests.Integrated
 {
     public class WootradeAuthenticatedMethodsSuite
     {
+        private const int TestOrderId = 33618629;
         private const string WootradeProductionEndpoint = "https://api.woo.network/";
         private IWootradeRestClient client;
 
@@ -21,28 +22,26 @@ namespace Wootrade.Tests.Integrated
             var apiKey = System.Environment.GetEnvironmentVariable("WOO_TESTS_API_KEY");
             var apiSecret = System.Environment.GetEnvironmentVariable("WOO_TESTS_API_SECRET");
 
-            clientOptions.ApiCredentials
-               = new CryptoExchange.Net.Authentication.ApiCredentials(apiKey, apiSecret);
-
             this.client = new WootradeRestClient(clientOptions);
         }
 
         [Fact(Skip = "Skipped")]
-        public async Task WootradeRestClient_CancelOrderAsync_Success()
+        public async Task WootradeRestClient_CancelOrderByClientIdAsync_Success()
         {
             var symbol = "SPOT_WOO_USDT";
-            var result = await client.CancelOrderAsync(symbol, 1);
+            var result = await client.CancelOrderByClientIdAsync(symbol, 1);
 
             Assert.NotNull(result);
             Assert.True(result.Success);
+            Assert.True(result.Data.Success);
             Assert.NotNull(result.Data);
-            Assert.Equal(symbol, result.Data.Symbol);
+            Assert.Equal("CANCEL_SENT", result.Data.Status);
         }
 
         [Fact]
         public async Task WootradeRestClient_GetCurrentHoldingsAsync_Success()
         {
-            var result = await client.GetCurrentHoldingAsync(true);
+            var result = await client.GetCurrentHoldingAsync(false);
 
             Assert.NotNull(result);
             Assert.True(result.Success);
@@ -50,18 +49,6 @@ namespace Wootrade.Tests.Integrated
             Assert.True(result.Data.Success);
             Assert.NotNull(result.Data.Holding);
             Assert.True(result.Data.Holding.Any());
-        }
-
-        [Fact(Skip = "Skipped")]
-        public async Task WootradeRestClient_GetOrderAsync_Success()
-        {
-            var result = await client.GetOrderAsync(1);
-
-            Assert.NotNull(result);
-            Assert.True(result.Success);
-            Assert.NotNull(result.Data);
-            Assert.True(result.Data.Success);
-            Assert.NotNull(result.Data.Symbol);
         }
 
         [Fact]
@@ -78,15 +65,50 @@ namespace Wootrade.Tests.Integrated
             Assert.True(result.Data.Bids.Any());
         }
 
+        //[Fact(Skip = "Skipped")]
+        [Fact]
+        public async Task WootradeRestClient_GetOrderByClientOrderIdAsync_Success()
+        {
+            var result = await client.GetOrderByClientOrderIdAsync(1);
+
+            Assert.NotNull(result);
+            Assert.True(result.Success);
+            Assert.NotNull(result.Data);
+            Assert.True(result.Data.Success);
+            Assert.NotNull(result.Data.Symbol);
+            Assert.Equal("SPOT_WOO_USDT", result.Data.Symbol);
+            Assert.Equal(15, result.Data.Quantity);
+            Assert.Equal(0.4m, result.Data.Price);
+            Assert.Equal(OrderSide.Buy, result.Data.Side);
+            Assert.Equal("Test", result.Data.Tag);
+        }
+
+        [Fact]
+        public async Task WootradeRestClient_GetOrderByWootradeOrderIdAsync_Success()
+        {
+            var result = await client.GetOrderByWootradeOrderIdAsync(TestOrderId);
+
+            Assert.NotNull(result);
+            Assert.True(result.Success);
+            Assert.NotNull(result.Data);
+            Assert.True(result.Data.Success);
+            Assert.NotNull(result.Data.Symbol);
+            Assert.Equal("SPOT_WOO_USDT", result.Data.Symbol);
+            Assert.Equal(15, result.Data.Quantity);
+            Assert.Equal(0.4m, result.Data.Price);
+            Assert.Equal(OrderSide.Buy, result.Data.Side);
+            Assert.Equal("Test", result.Data.Tag);
+        }
+
         [Fact(Skip = "Skipped")]
         public async Task WootradeRestClient_PlaceOrderAsync_Success()
         {
             WootradePlaceOrder order = new WootradePlaceOrder();
 
             order.ClientOrderId = 1;
-            order.Price = 0.1m;
-            order.Quantity = 100m;
-            order.Side = OrderSide.Sell;
+            order.Price = 0.4m;
+            order.Quantity = 15;
+            order.Side = OrderSide.Buy;
             order.Symbol = "SPOT_WOO_USDT";
             order.Tag = "Test";
             order.Type = OrderType.Limit;
@@ -98,9 +120,9 @@ namespace Wootrade.Tests.Integrated
             Assert.NotNull(result.Data);
             Assert.True(result.Data.Success);
 
-            Assert.True(result.Data.Price == 0.1m);
+            Assert.True(result.Data.Price == 0.4m);
             Assert.NotNull(result.Data.Quantity);
-            Assert.True(result.Data.Quantity.Value == 100m);
+            Assert.True(result.Data.Quantity.Value == 15m);
         }
     }
 }

--- a/src/Wootrade.Tests/Integrated/WootradeAuthenticatedMethodsSuite.cs
+++ b/src/Wootrade.Tests/Integrated/WootradeAuthenticatedMethodsSuite.cs
@@ -22,6 +22,9 @@ namespace Wootrade.Tests.Integrated
             var apiKey = System.Environment.GetEnvironmentVariable("WOO_TESTS_API_KEY");
             var apiSecret = System.Environment.GetEnvironmentVariable("WOO_TESTS_API_SECRET");
 
+            clientOptions.ApiCredentials
+                = new CryptoExchange.Net.Authentication.ApiCredentials(apiKey, apiSecret);
+
             this.client = new WootradeRestClient(clientOptions);
         }
 

--- a/src/Wootrade.Tests/Integrated/WootradeAuthenticatedMethodsSuite.cs
+++ b/src/Wootrade.Tests/Integrated/WootradeAuthenticatedMethodsSuite.cs
@@ -1,7 +1,9 @@
 ﻿using System.Linq;
 using System.Threading.Tasks;
 using Wootrade.Interfaces;
+using Wootrade.Model.Enums;
 using Wootrade.Model.Spot;
+using Wootrade.Model.SpotData;
 using Xunit;
 
 namespace Wootrade.Tests.Integrated
@@ -19,10 +21,44 @@ namespace Wootrade.Tests.Integrated
             var apiKey = System.Environment.GetEnvironmentVariable("WOO_TESTS_API_KEY");
             var apiSecret = System.Environment.GetEnvironmentVariable("WOO_TESTS_API_SECRET");
 
-            clientOptions.ApiCredentials
-                = new CryptoExchange.Net.Authentication.ApiCredentials(apiKey, apiSecret);
-
             this.client = new WootradeRestClient(clientOptions);
+        }
+
+        [Fact(Skip = "Skipped")]
+        public async Task WootradeRestClient_CancelOrderAsync_Success()
+        {
+            var symbol = "SPOT_WOO_USDT";
+            var result = await client.CancelOrderAsync(symbol, 1);
+
+            Assert.NotNull(result);
+            Assert.True(result.Success);
+            Assert.NotNull(result.Data);
+            Assert.Equal(symbol, result.Data.Symbol);
+        }
+
+        [Fact]
+        public async Task WootradeRestClient_GetCurrentHoldingsAsync_Success()
+        {
+            var result = await client.GetCurrentHoldingAsync(true);
+
+            Assert.NotNull(result);
+            Assert.True(result.Success);
+            Assert.NotNull(result.Data);
+            Assert.True(result.Data.Success);
+            Assert.NotNull(result.Data.Holding);
+            Assert.True(result.Data.Holding.Any());
+        }
+
+        [Fact(Skip = "Skipped")]
+        public async Task WootradeRestClient_GetOrderAsync_Success()
+        {
+            var result = await client.GetOrderAsync(1);
+
+            Assert.NotNull(result);
+            Assert.True(result.Success);
+            Assert.NotNull(result.Data);
+            Assert.True(result.Data.Success);
+            Assert.NotNull(result.Data.Symbol);
         }
 
         [Fact]
@@ -37,6 +73,31 @@ namespace Wootrade.Tests.Integrated
             Assert.NotNull(result.Data.Symbol);
             Assert.True(result.Data.Asks.Any());
             Assert.True(result.Data.Bids.Any());
+        }
+
+        [Fact(Skip = "Skipped")]
+        public async Task WootradeRestClient_PlaceOrderAsync_Success()
+        {
+            WootradePlaceOrder order = new WootradePlaceOrder();
+
+            order.ClientOrderId = 1;
+            order.Price = 0.1m;
+            order.Quantity = 100m;
+            order.Side = OrderSide.Sell;
+            order.Symbol = "SPOT_WOO_USDT";
+            order.Tag = "Test";
+            order.Type = OrderType.Limit;
+
+            var result = await client.PlaceOrderAsync(order);
+
+            Assert.NotNull(result);
+            Assert.True(result.Success);
+            Assert.NotNull(result.Data);
+            Assert.True(result.Data.Success);
+
+            Assert.True(result.Data.Price == 0.1m);
+            Assert.NotNull(result.Data.Quantity);
+            Assert.True(result.Data.Quantity.Value == 100m);
         }
     }
 }

--- a/src/Wootrade.Tests/Integrated/WootradeAuthenticatedMethodsSuite.cs
+++ b/src/Wootrade.Tests/Integrated/WootradeAuthenticatedMethodsSuite.cs
@@ -21,6 +21,9 @@ namespace Wootrade.Tests.Integrated
             var apiKey = System.Environment.GetEnvironmentVariable("WOO_TESTS_API_KEY");
             var apiSecret = System.Environment.GetEnvironmentVariable("WOO_TESTS_API_SECRET");
 
+            clientOptions.ApiCredentials
+               = new CryptoExchange.Net.Authentication.ApiCredentials(apiKey, apiSecret);
+
             this.client = new WootradeRestClient(clientOptions);
         }
 

--- a/src/Wootrade/Converters/OrderSideConverter.cs
+++ b/src/Wootrade/Converters/OrderSideConverter.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using CryptoExchange.Net.Converters;
+using Newtonsoft.Json;
+using Wootrade.Model.Enums;
+
+namespace Wootrade.Converters
+{
+    internal class OrderSideConverter : BaseConverter<OrderSide>
+    {
+        public OrderSideConverter() : this(true)
+        {
+        }
+
+        public OrderSideConverter(bool quotes) : base(quotes)
+        {
+        }
+
+        protected override List<KeyValuePair<OrderSide, string>> Mapping => new List<KeyValuePair<OrderSide, string>>
+        {
+            new KeyValuePair<OrderSide, string>(OrderSide.Buy, "BUY"),
+            new KeyValuePair<OrderSide, string>(OrderSide.Sell, "SELL")
+        };
+
+        public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+        {
+            return Mapping.Single(v => v.Value == (string?)reader.Value).Key;
+        }
+    }
+}

--- a/src/Wootrade/Converters/OrderStatusConverter.cs
+++ b/src/Wootrade/Converters/OrderStatusConverter.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using CryptoExchange.Net.Converters;
+using Newtonsoft.Json;
+using Wootrade.Model.Enums;
+
+namespace Wootrade.Converters
+{
+    internal class OrderStatusConverter : BaseConverter<OrderStatus>
+    {
+        public OrderStatusConverter() : this(true)
+        {
+        }
+
+        public OrderStatusConverter(bool quotes) : base(quotes)
+        {
+        }
+
+        protected override List<KeyValuePair<OrderStatus, string>> Mapping => new List<KeyValuePair<OrderStatus, string>>
+        {
+            new KeyValuePair<OrderStatus, string>(OrderStatus.New, "NEW"),
+            new KeyValuePair<OrderStatus, string>(OrderStatus.PartialFilled, "PARTIAL_FILLED"),
+            new KeyValuePair<OrderStatus, string>(OrderStatus.Rejected, "REJECTED"),
+            new KeyValuePair<OrderStatus, string>(OrderStatus.Filled, "FILLED"),
+            new KeyValuePair<OrderStatus, string>(OrderStatus.Incomplete, "INCOMPLETE"),
+            new KeyValuePair<OrderStatus, string>(OrderStatus.Complete, "COMPLETED")
+        };
+
+        public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+        {
+            return Mapping.Single(v => v.Value == (string?)reader.Value).Key;
+        }
+    }
+}

--- a/src/Wootrade/Converters/OrderTypeConverter.cs
+++ b/src/Wootrade/Converters/OrderTypeConverter.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Newtonsoft.Json;
+using Wootrade.Model.Enums;
+
+namespace Wootrade.Converters
+{
+    internal class OrderTypeConverter : JsonConverter
+    {
+        private readonly bool quotes;
+
+        private readonly Dictionary<OrderType, string> values = new Dictionary<OrderType, string>
+        {
+            { OrderType.Limit, "LIMIT" },
+            { OrderType.Market, "MARKET" },
+            { OrderType.Ask, "ASK" },
+            { OrderType.Bid, "BID" },
+            { OrderType.FOK, "FOK" },
+            { OrderType.IOC, "IOC" }
+        };
+
+        public OrderTypeConverter()
+        {
+            quotes = true;
+        }
+
+        public OrderTypeConverter(bool useQuotes)
+        {
+            quotes = useQuotes;
+        }
+
+        public override bool CanConvert(Type objectType)
+        {
+            return objectType == typeof(OrderType);
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object? existingValue, JsonSerializer serializer)
+        {
+            return values.Single(v => v.Value == (string?)reader.Value).Key;
+        }
+
+        public override void WriteJson(JsonWriter writer, object? value, JsonSerializer serializer)
+        {
+            if (quotes)
+                writer.WriteValue(values[(OrderType)value!]);
+            else
+                writer.WriteRawValue(values[(OrderType)value!]);
+        }
+    }
+}

--- a/src/Wootrade/Interfaces/IWootradeRestClient.cs
+++ b/src/Wootrade/Interfaces/IWootradeRestClient.cs
@@ -14,7 +14,22 @@ namespace Wootrade.Interfaces
         /// <param name="symbol"></param>
         /// <param name="clientOrderId">The client_order_id that wish to cancel</param>
         /// <returns></returns>
-        Task<WebCallResult<WootradeCancelOrderResponse>> CancelOrderAsync(string symbol, int clientOrderId);
+        Task<WebCallResult<WootradeCancelOrderResponse>> CancelOrderByClientIdAsync(string symbol, int clientOrderId);
+
+        /// <summary>
+        /// Cancel order by wootrade order id
+        /// </summary>
+        /// <param name="symbol"></param>
+        /// <param name="wootradeOrderId">Order id created by Wootrade API</param>
+        /// <returns></returns>
+        Task<WebCallResult<WootradeCancelOrderResponse>> CancelOrderByWootradeOrderIdAsync(string symbol, int wootradeOrderId);
+
+        /// <summary>
+        /// Cancel all orders for a symbol
+        /// </summary>
+        /// <param name="symbol"></param>
+        /// <returns></returns>
+        Task<WebCallResult<WootradeCancelOrderResponse>> CancelOrdersBySymbolAsync(string symbol);
 
         /// <summary>
         /// Get available tokens that WooTrade supported, it need to use when you call get deposit
@@ -30,18 +45,25 @@ namespace Wootrade.Interfaces
         Task<WebCallResult<WootradeCurrentHolding>> GetCurrentHoldingAsync(bool all = false);
 
         /// <summary>
-        /// Get specific order detail by client_order_id
-        /// </summary>
-        /// <param name="clientOrderId">customized order_id when placing order</param>
-        /// <returns></returns>
-        Task<WebCallResult<WootradeOrderInfo>> GetOrderAsync(int clientOrderId);
-
-        /// <summary>
         /// SNAPSHOT of current orderbook. Price of asks/bids are in descending order
         /// </summary>
         /// <param name="symbol">Symbol that you want to query</param>
         /// <returns></returns>
         Task<WebCallResult<WootradeOrderBook>> GetOrderBookAsync(string symbol);
+
+        /// <summary>
+        /// Get specific order detail by client_order_id
+        /// </summary>
+        /// <param name="clientOrderId">customized order_id when placing order</param>
+        /// <returns></returns>
+        Task<WebCallResult<WootradeOrderInfo>> GetOrderByClientOrderIdAsync(int clientOrderId);
+
+        /// <summary>
+        /// Get order by Wootrade order id
+        /// </summary>
+        /// <param name="orderId"></param>
+        /// <returns></returns>
+        Task<WebCallResult<WootradeOrderInfo>> GetOrderByWootradeOrderIdAsync(int orderId);
 
         /// <summary>
         /// Get latest market trades

--- a/src/Wootrade/Interfaces/IWootradeRestClient.cs
+++ b/src/Wootrade/Interfaces/IWootradeRestClient.cs
@@ -1,17 +1,40 @@
-﻿using System.Threading.Tasks;
+﻿using System.Threading;
+using System.Threading.Tasks;
 using CryptoExchange.Net.Objects;
 using Wootrade.Model.MarketData;
+using Wootrade.Model.SpotData;
 
 namespace Wootrade.Interfaces
 {
     public interface IWootradeRestClient
     {
         /// <summary>
+        /// Cancel order by client order id
+        /// </summary>
+        /// <param name="symbol"></param>
+        /// <param name="clientOrderId">The client_order_id that wish to cancel</param>
+        /// <returns></returns>
+        Task<WebCallResult<WootradeCancelOrderResponse>> CancelOrderAsync(string symbol, int clientOrderId);
+
+        /// <summary>
         /// Get available tokens that WooTrade supported, it need to use when you call get deposit
         /// address or withdraw api.
         /// </summary>
         /// <returns></returns>
         Task<WebCallResult<WootradeAvailableTokens>> GetAvailableTokensAsync();
+
+        /// <summary>
+        /// Holding summary of client
+        /// </summary>
+        /// <returns></returns>
+        Task<WebCallResult<WootradeCurrentHolding>> GetCurrentHoldingAsync(bool all = false);
+
+        /// <summary>
+        /// Get specific order detail by client_order_id
+        /// </summary>
+        /// <param name="clientOrderId">customized order_id when placing order</param>
+        /// <returns></returns>
+        Task<WebCallResult<WootradeOrderInfo>> GetOrderAsync(int clientOrderId);
 
         /// <summary>
         /// SNAPSHOT of current orderbook. Price of asks/bids are in descending order
@@ -39,5 +62,13 @@ namespace Wootrade.Interfaces
         /// </summary>
         /// <returns></returns>
         Task<WebCallResult<WootradeExchangeInfo>> GetSymbolsAsync();
+
+        /// <summary>
+        /// Place order maker/taker, the order executed information will be update from websocket
+        /// stream. will response immediately with an order created message
+        /// </summary>
+        /// <param name="order"></param>
+        /// <returns></returns>
+        Task<WebCallResult<WootradeOrderPlacedResponse>> PlaceOrderAsync(WootradePlaceOrder order, CancellationToken ct = default);
     }
 }

--- a/src/Wootrade/Model/Enums/OrderSide.cs
+++ b/src/Wootrade/Model/Enums/OrderSide.cs
@@ -1,0 +1,10 @@
+﻿namespace Wootrade.Model.Enums
+{
+    public enum OrderSide
+    {
+        Unknown = 0,
+
+        Buy = 1,
+        Sell = 2
+    }
+}

--- a/src/Wootrade/Model/Enums/OrderStatus.cs
+++ b/src/Wootrade/Model/Enums/OrderStatus.cs
@@ -1,0 +1,15 @@
+﻿namespace Wootrade.Model.Enums
+{
+    public enum OrderStatus
+    {
+        Unknown = 0,
+
+        New = 1,
+        Cancelled = 2,
+        PartialFilled = 3,
+        Filled = 4,
+        Rejected = 5,
+        Incomplete = 6,
+        Complete = 7
+    }
+}

--- a/src/Wootrade/Model/Enums/OrderType.cs
+++ b/src/Wootrade/Model/Enums/OrderType.cs
@@ -1,0 +1,39 @@
+﻿namespace Wootrade.Model.Enums
+{
+    public enum OrderType
+    {
+        None = 0,
+
+        /// <summary>
+        /// it matches until all size executed
+        /// </summary>
+        Market = 1,
+
+        /// <summary>
+        /// it matches as much as possible at the order_price. If not fully executed, then remaining
+        /// quantity will be cancelled.
+        /// </summary>
+        IOC = 2,
+
+        /// <summary>
+        /// if the order can be fully executed at the order_price then the order gets fully executed
+        /// otherwise would be cancelled without any execution
+        /// </summary>
+        FOK = 3,
+
+        /// <summary>
+        /// the order price is guranteed to be the best ask price of the orderbook if it gets accepted
+        /// </summary>
+        Ask = 4,
+
+        /// <summary>
+        /// the order price is guranteed to be the best bid price of the orderbook if it gets accepted
+        /// </summary>
+        Bid = 5,
+
+        /// <summary>
+        /// the order price is set and guranteed
+        /// </summary>
+        Limit = 6
+    }
+}

--- a/src/Wootrade/Model/Shared/WootradeKlineBase.cs
+++ b/src/Wootrade/Model/Shared/WootradeKlineBase.cs
@@ -64,7 +64,7 @@ namespace Wootrade.Model.Shared
         public DateTime StartTime { get; set; }
 
         [JsonProperty("symbol")]
-        public string Symbol { get; set; }
+        public string Symbol { get; set; } = "";
 
         /// <summary>
         /// The type

--- a/src/Wootrade/Model/Shared/WootradeRestError.cs
+++ b/src/Wootrade/Model/Shared/WootradeRestError.cs
@@ -8,7 +8,7 @@ namespace Wootrade.Model.Shared
         public int Code { get; set; }
 
         [JsonProperty("message")]
-        public string Message { get; set; }
+        public string Message { get; set; } = "";
 
         public string GetErrorName()
         {

--- a/src/Wootrade/Model/Shared/WootradeRestError.cs
+++ b/src/Wootrade/Model/Shared/WootradeRestError.cs
@@ -1,0 +1,73 @@
+﻿using Newtonsoft.Json;
+
+namespace Wootrade.Model.Shared
+{
+    public class WootradeRestError
+    {
+        [JsonProperty("code")]
+        public int Code { get; set; }
+
+        [JsonProperty("message")]
+        public string Message { get; set; }
+
+        public string GetErrorName()
+        {
+            switch (Code)
+            {
+                case -1000:
+                    return "UNKNOWN";
+
+                case -1001:
+                    return "INVALID_SIGNATURE";
+
+                case -1002:
+                    return "UNAUTHORIZED";
+
+                case -1003:
+                    return "TOO_MANY_REQUEST";
+
+                case -1004:
+                    return "UNKNOWN_PARAM";
+
+                case -1005:
+                    return "INVALID_PARAM";
+
+                case -1006:
+                    return "RESOURCE_NOT_FOUND";
+
+                case -1007:
+                    return "DUPLICATE_REQUEST";
+
+                case -1008:
+                    return "QUANTITY_TOO_HIGH";
+
+                case -1009:
+                    return "CAN_NOT_WITHDRAWAL";
+
+                case -1011:
+                    return "RPC_NOT_CONNECT";
+
+                case -1012:
+                    return "RPC_REJECT";
+
+                case -1101:
+                    return "RISK_TOO_HIGH";
+
+                case -1102:
+                    return "MIN_NOTIONAL";
+
+                case -1103:
+                    return "PRICE_FILTER";
+
+                case -1104:
+                    return "SIZE_FILTER";
+
+                case -1105:
+                    return "PERCENTAGE_FILTER";
+
+                default:
+                    return "UNKNOWN";
+            }
+        }
+    }
+}

--- a/src/Wootrade/Model/SpotData/WootradeCancelOrderResponse.cs
+++ b/src/Wootrade/Model/SpotData/WootradeCancelOrderResponse.cs
@@ -1,0 +1,16 @@
+﻿using Newtonsoft.Json;
+
+namespace Wootrade.Model.SpotData
+{
+    public class WootradeCancelOrderResponse
+    {
+        /// <summary>
+        /// The client_order_id that wish to cancel
+        /// </summary>
+        [JsonProperty("client_order_id")]
+        public int ClientOrderId { get; set; }
+
+        [JsonProperty("symbol")]
+        public string Symbol { get; set; }
+    }
+}

--- a/src/Wootrade/Model/SpotData/WootradeCancelOrderResponse.cs
+++ b/src/Wootrade/Model/SpotData/WootradeCancelOrderResponse.cs
@@ -4,13 +4,10 @@ namespace Wootrade.Model.SpotData
 {
     public class WootradeCancelOrderResponse
     {
-        /// <summary>
-        /// The client_order_id that wish to cancel
-        /// </summary>
-        [JsonProperty("client_order_id")]
-        public int ClientOrderId { get; set; }
+        [JsonProperty("status")]
+        public string Status { get; set; }
 
-        [JsonProperty("symbol")]
-        public string Symbol { get; set; }
+        [JsonProperty("success")]
+        public bool Success { get; set; }
     }
 }

--- a/src/Wootrade/Model/SpotData/WootradeCancelOrderResponse.cs
+++ b/src/Wootrade/Model/SpotData/WootradeCancelOrderResponse.cs
@@ -5,7 +5,7 @@ namespace Wootrade.Model.SpotData
     public class WootradeCancelOrderResponse
     {
         [JsonProperty("status")]
-        public string Status { get; set; }
+        public string Status { get; set; } = "";
 
         [JsonProperty("success")]
         public bool Success { get; set; }

--- a/src/Wootrade/Model/SpotData/WootradeCurrentHolding.cs
+++ b/src/Wootrade/Model/SpotData/WootradeCurrentHolding.cs
@@ -1,0 +1,14 @@
+﻿using System.Collections.Generic;
+using Newtonsoft.Json;
+
+namespace Wootrade.Model.SpotData
+{
+    public class WootradeCurrentHolding
+    {
+        [JsonProperty("holding")]
+        public IEnumerable<WootradeCurrentHoldingEntry> Holding { get; set; } = new List<WootradeCurrentHoldingEntry>();
+
+        [JsonProperty("success")]
+        public bool Success { get; set; }
+    }
+}

--- a/src/Wootrade/Model/SpotData/WootradeCurrentHoldingEntry.cs
+++ b/src/Wootrade/Model/SpotData/WootradeCurrentHoldingEntry.cs
@@ -10,7 +10,7 @@ namespace Wootrade.Model.SpotData
         public decimal Holding { get; set; }
 
         [JsonProperty("token")]
-        public string Token { get; set; }
+        public string Token { get; set; } = "";
 
         [JsonProperty("updated_time"), JsonConverter(typeof(TimestampSecondsConverter))]
         public DateTime UpdatedTime { get; set; }

--- a/src/Wootrade/Model/SpotData/WootradeCurrentHoldingEntry.cs
+++ b/src/Wootrade/Model/SpotData/WootradeCurrentHoldingEntry.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using CryptoExchange.Net.Converters;
+using Newtonsoft.Json;
+
+namespace Wootrade.Model.SpotData
+{
+    public class WootradeCurrentHoldingEntry
+    {
+        [JsonProperty("holding")]
+        public decimal Holding { get; set; }
+
+        [JsonProperty("token")]
+        public string Token { get; set; }
+
+        [JsonProperty("updated_time"), JsonConverter(typeof(TimestampSecondsConverter))]
+        public DateTime UpdatedTime { get; set; }
+    }
+}

--- a/src/Wootrade/Model/SpotData/WootradeOrderInfo.cs
+++ b/src/Wootrade/Model/SpotData/WootradeOrderInfo.cs
@@ -10,22 +10,26 @@ namespace Wootrade.Model.SpotData
     public class WootradeOrderInfo
     {
         [JsonProperty("amount")]
-        public decimal Amount { get; set; }
+        public decimal? Amount { get; set; }
 
         [JsonProperty("client_order_id")]
-        public int ClientOrderId { get; set; }
+        public int? ClientOrderId { get; set; }
 
         [JsonProperty("created_time"), JsonConverter(typeof(TimestampSecondsConverter))]
         public DateTime CreatedTime { get; set; }
 
         [JsonProperty("executed")]
-        public decimal Executed { get; set; }
+        public bool Executed { get; set; }
 
         [JsonProperty("price")]
         public decimal Price { get; set; }
 
+
+        [JsonProperty("average_executed_price")]
+        public decimal? AverageExecutedPrice { get; set; }
+
         [JsonProperty("quantity")]
-        public decimal Quantity { get; set; }
+        public decimal? Quantity { get; set; }
 
         [JsonProperty("side"), JsonConverter(typeof(OrderSideConverter))]
         public OrderSide Side { get; set; }

--- a/src/Wootrade/Model/SpotData/WootradeOrderInfo.cs
+++ b/src/Wootrade/Model/SpotData/WootradeOrderInfo.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using CryptoExchange.Net.Converters;
+using Newtonsoft.Json;
+using Wootrade.Converters;
+using Wootrade.Model.Enums;
+
+namespace Wootrade.Model.SpotData
+{
+    public class WootradeOrderInfo
+    {
+        [JsonProperty("amount")]
+        public decimal Amount { get; set; }
+
+        [JsonProperty("client_order_id")]
+        public int ClientOrderId { get; set; }
+
+        [JsonProperty("created_time"), JsonConverter(typeof(TimestampSecondsConverter))]
+        public DateTime CreatedTime { get; set; }
+
+        [JsonProperty("executed")]
+        public decimal Executed { get; set; }
+
+        [JsonProperty("price")]
+        public decimal Price { get; set; }
+
+        [JsonProperty("quantity")]
+        public decimal Quantity { get; set; }
+
+        [JsonProperty("side"), JsonConverter(typeof(OrderSideConverter))]
+        public OrderSide Side { get; set; }
+
+        [JsonProperty("status"), JsonConverter(typeof(OrderStatusConverter))]
+        public OrderStatus Status { get; set; }
+
+        [JsonProperty("success")]
+        public bool Success { get; set; }
+
+        [JsonProperty("symbol")]
+        public string Symbol { get; set; }
+
+        [JsonProperty("order_tag")]
+        public string Tag { get; set; }
+
+        [JsonProperty("transactions")]
+        public IEnumerable<WootradeOrderInfoTransaction> Transactions { get; set; } = new List<WootradeOrderInfoTransaction>();
+
+        [JsonProperty("type"), JsonConverter(typeof(OrderTypeConverter))]
+        public OrderType Type { get; set; }
+
+        [JsonProperty("visible")]
+        public decimal Visible { get; set; }
+
+        [JsonProperty("order_id")]
+        public int WootradeOrderId { get; set; }
+    }
+}

--- a/src/Wootrade/Model/SpotData/WootradeOrderInfo.cs
+++ b/src/Wootrade/Model/SpotData/WootradeOrderInfo.cs
@@ -12,6 +12,9 @@ namespace Wootrade.Model.SpotData
         [JsonProperty("amount")]
         public decimal? Amount { get; set; }
 
+        [JsonProperty("average_executed_price")]
+        public decimal? AverageExecutedPrice { get; set; }
+
         [JsonProperty("client_order_id")]
         public int? ClientOrderId { get; set; }
 
@@ -23,10 +26,6 @@ namespace Wootrade.Model.SpotData
 
         [JsonProperty("price")]
         public decimal Price { get; set; }
-
-
-        [JsonProperty("average_executed_price")]
-        public decimal? AverageExecutedPrice { get; set; }
 
         [JsonProperty("quantity")]
         public decimal? Quantity { get; set; }
@@ -41,10 +40,10 @@ namespace Wootrade.Model.SpotData
         public bool Success { get; set; }
 
         [JsonProperty("symbol")]
-        public string Symbol { get; set; }
+        public string Symbol { get; set; } = "";
 
         [JsonProperty("order_tag")]
-        public string Tag { get; set; }
+        public string Tag { get; set; } = "";
 
         [JsonProperty("transactions")]
         public IEnumerable<WootradeOrderInfoTransaction> Transactions { get; set; } = new List<WootradeOrderInfoTransaction>();

--- a/src/Wootrade/Model/SpotData/WootradeOrderInfoTransaction.cs
+++ b/src/Wootrade/Model/SpotData/WootradeOrderInfoTransaction.cs
@@ -21,7 +21,7 @@ namespace Wootrade.Model.SpotData
         public decimal Fee { get; set; }
 
         [JsonProperty("fee_asset")]
-        public string FeeAsset { get; set; }
+        public string FeeAsset { get; set; } = "";
 
         [JsonProperty("id")]
         public int Id { get; set; }
@@ -33,7 +33,7 @@ namespace Wootrade.Model.SpotData
         public OrderSide Side { get; set; }
 
         [JsonProperty("symbol")]
-        public string Symbol { get; set; }
+        public string Symbol { get; set; } = "";
 
         [JsonProperty("order_id")]
         public int WootradeOrderId { get; set; }

--- a/src/Wootrade/Model/SpotData/WootradeOrderInfoTransaction.cs
+++ b/src/Wootrade/Model/SpotData/WootradeOrderInfoTransaction.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using CryptoExchange.Net.Converters;
+using Newtonsoft.Json;
+using Wootrade.Converters;
+using Wootrade.Model.Enums;
+
+namespace Wootrade.Model.SpotData
+{
+    public class WootradeOrderInfoTransaction
+    {
+        [JsonProperty("executed_price")]
+        public decimal ExecutedPrice { get; set; }
+
+        [JsonProperty("executed_quantity")]
+        public decimal ExecutedQuantity { get; set; }
+
+        [JsonProperty("executed_timestamp"), JsonConverter(typeof(TimestampSecondsConverter))]
+        public DateTime ExecutedTimestamp { get; set; }
+
+        [JsonProperty("fee")]
+        public decimal Fee { get; set; }
+
+        [JsonProperty("fee_asset")]
+        public string FeeAsset { get; set; }
+
+        [JsonProperty("id")]
+        public int Id { get; set; }
+
+        [JsonProperty("is_maker")]
+        public bool IsMaker { get; set; }
+
+        [JsonProperty("side"), JsonConverter(typeof(OrderSideConverter))]
+        public OrderSide Side { get; set; }
+
+        [JsonProperty("symbol")]
+        public string Symbol { get; set; }
+
+        [JsonProperty("order_id")]
+        public int WootradeOrderId { get; set; }
+    }
+}

--- a/src/Wootrade/Model/SpotData/WootradePlaceOrder.cs
+++ b/src/Wootrade/Model/SpotData/WootradePlaceOrder.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using Dawn;
+using Newtonsoft.Json;
+using Wootrade.Model.Enums;
+
+namespace Wootrade.Model.SpotData
+{
+    public class WootradeOrderPlacedResponse
+    {
+        [JsonProperty("order_amount")]
+        public decimal? Amount { get; set; }
+
+        [JsonProperty("order_id")]
+        public int OrderId { get; set; }
+
+        [JsonProperty("order_price")]
+        public decimal? Price { get; set; }
+
+        [JsonProperty("order_quantity")]
+        public decimal? Quantity { get; set; }
+
+        [JsonProperty("success")]
+        public bool Success { get; set; }
+
+        [JsonProperty("order_type")]
+        public OrderType Type { get; set; }
+    }
+
+    public class WootradePlaceOrder
+    {
+        /// <summary>
+        /// For MARKET/ASK/BID order, the order size in terms of quote currency
+        /// </summary>
+        [JsonProperty("order_amount")]
+        public decimal? Amount { get; set; }
+
+        /// <summary>
+        /// number for scope : from 0 to 9223372036854775807. (default: 0)
+        /// </summary>
+        [JsonProperty("client_order_id")]
+        public int? ClientOrderId { get; set; }
+
+        /// <summary>
+        /// If order_type is MARKET, then is not required, otherwise this parameter is required.
+        /// </summary>
+        [JsonProperty("order_price")]
+        public decimal? Price { get; set; }
+
+        /// <summary>
+        /// For MARKET/ASK/BID order, if order_amount is given, it is not required.
+        /// </summary>
+        [JsonProperty("order_quantity")]
+        public decimal? Quantity { get; set; }
+
+        /// <summary>
+        /// SELL/BUY
+        /// </summary>
+        [JsonProperty("side")]
+        public OrderSide Side { get; set; }
+
+        [JsonProperty("symbol")]
+        public string Symbol { get; set; }
+
+        /// <summary>
+        /// An optional tag for this order. (default: default)
+        /// </summary>
+        [JsonProperty("order_tag")]
+        public string? Tag { get; set; }
+
+        /// <summary>
+        /// LIMIT/MARKET/IOC/FOK/POST_ONLY
+        /// </summary>
+        [JsonProperty("order_type")]
+        public OrderType Type { get; set; }
+
+        /// <summary>
+        /// The order quantity shown on orderbook. (default: equal to order_quantity)
+        /// </summary>
+        [JsonProperty("visible_quantity")]
+        public decimal? VisibleQuantity { get; set; }
+
+        internal void ThrowValidationPlaceOrder()
+        {
+            Guard.Argument(this.Symbol).NotNull();
+            Guard.Argument(this.Side).NotDefault();
+            Guard.Argument(this.Type).NotDefault();
+
+            if (this.Quantity != null
+                            &&
+               !(
+                   this.Type == OrderType.Market
+                   ||
+                   this.Type == OrderType.Ask
+                   ||
+                   this.Type == OrderType.Bid
+                   ||
+                   this.Type == OrderType.Limit
+               ))
+                throw new ArgumentException("Quantity is only valid for Limit, Market, Ask and Bid orders");
+
+            if (this.Amount != null
+               &&
+               !(
+                   this.Type == OrderType.Market
+                   ||
+                   this.Type == OrderType.Ask
+                   ||
+                   this.Type == OrderType.Bid
+                   ||
+                   this.Type == OrderType.Limit
+               )
+           )
+                throw new ArgumentException("Amount is only valid for Limit, Market, Ask and Bid orders");
+
+            if (this.Amount != null && this.Quantity != null)
+                throw new ArgumentException("The order would be rejected if both order_amount and order_quantity are provided");
+
+            if (this.Quantity != null)
+            {
+                var orderValue = this.Quantity * this.Price;
+
+                if (orderValue < 5m)
+                {
+                    throw new ArgumentException("Order value should be greater or equal to 5.0");
+                }
+            }
+        }
+    }
+}

--- a/src/Wootrade/Model/SpotData/WootradePlaceOrder.cs
+++ b/src/Wootrade/Model/SpotData/WootradePlaceOrder.cs
@@ -59,7 +59,7 @@ namespace Wootrade.Model.SpotData
         public OrderSide Side { get; set; }
 
         [JsonProperty("symbol")]
-        public string Symbol { get; set; }
+        public string Symbol { get; set; } = "";
 
         /// <summary>
         /// An optional tag for this order. (default: default)
@@ -123,6 +123,8 @@ namespace Wootrade.Model.SpotData
                 {
                     throw new ArgumentException("Order value should be greater or equal to 5.0");
                 }
+
+                Guard.Argument(this.Quantity).NotNegative();
             }
         }
     }

--- a/src/Wootrade/Wootrade.csproj
+++ b/src/Wootrade/Wootrade.csproj
@@ -11,7 +11,7 @@
     <PackageId>Wootrade.Net</PackageId>
     <Authors>rodrigobelo</Authors>
 
-    <Description>Wootrade.Net is a .Net wrapper for the Wootrade API (beta)</Description>
+    <Description>Wootrade.Net is a .Net wrapper for the Wootrade API (alpha)</Description>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageTags>Wootrade Wootrade.Net C# .Net CryptoCurrency Exchange API wrapper</PackageTags>
     <RepositoryType>git</RepositoryType>

--- a/src/Wootrade/WootradeAuthenticationProvider.cs
+++ b/src/Wootrade/WootradeAuthenticationProvider.cs
@@ -55,9 +55,7 @@ namespace Wootrade
 
         public override Dictionary<string, object> AddAuthenticationToParameters(string uri, HttpMethod method, Dictionary<string, object> parameters, bool signed, PostParameters postParameterPosition, ArrayParametersSerialization arraySerialization)
         {
-            return new Dictionary<string, object>();
-
-            throw new NotImplementedException();
+            return parameters;
         }
 
         public override string Sign(string toSign)

--- a/src/Wootrade/WootradeAuthenticationProvider.cs
+++ b/src/Wootrade/WootradeAuthenticationProvider.cs
@@ -67,7 +67,7 @@ namespace Wootrade
         {
             string signData;
 
-            if (method == HttpMethod.Get || method == HttpMethod.Delete || (postParameterPosition == PostParameters.InUri))
+            if (method == HttpMethod.Get || (postParameterPosition == PostParameters.InUri))
             {
                 signData = parameters.CreateParamString(true, arraySerialization);
             }

--- a/src/Wootrade/WootradeRestClient.cs
+++ b/src/Wootrade/WootradeRestClient.cs
@@ -30,7 +30,7 @@ namespace Wootrade
             this.requestBodyFormat = RequestBodyFormat.FormData;
         }
 
-        public async Task<WebCallResult<WootradeCancelOrderResponse>> CancelOrderAsync(string symbol, int clientOrderId)
+        public async Task<WebCallResult<WootradeCancelOrderResponse>> CancelOrderByClientIdAsync(string symbol, int clientOrderId)
         {
             var parameters = new Dictionary<string, object>
             {
@@ -38,7 +38,32 @@ namespace Wootrade
                 { "client_order_id", clientOrderId.ToString() }
             };
 
-            var result = await SendRequest<WootradeCancelOrderResponse>(this.GetUri("client", false), HttpMethod.Delete, CancellationToken.None, parameters, true).ConfigureAwait(false);
+            var result = await SendRequest<WootradeCancelOrderResponse>(this.GetUri("client/order", false), HttpMethod.Delete, CancellationToken.None, parameters, true).ConfigureAwait(false);
+
+            return result;
+        }
+
+        public async Task<WebCallResult<WootradeCancelOrderResponse>> CancelOrderByWootradeOrderIdAsync(string symbol, int wootradeOrderId)
+        {
+            var parameters = new Dictionary<string, object>
+            {
+                { "symbol", symbol },
+                { "order_id", wootradeOrderId.ToString() }
+            };
+
+            var result = await SendRequest<WootradeCancelOrderResponse>(this.GetUri("order", false), HttpMethod.Delete, CancellationToken.None, parameters, true).ConfigureAwait(false);
+
+            return result;
+        }
+
+        public async Task<WebCallResult<WootradeCancelOrderResponse>> CancelOrdersBySymbolAsync(string symbol)
+        {
+            var parameters = new Dictionary<string, object>
+            {
+                { "symbol", symbol }
+            };
+
+            var result = await SendRequest<WootradeCancelOrderResponse>(this.GetUri("orders", false), HttpMethod.Delete, CancellationToken.None, parameters, true).ConfigureAwait(false);
 
             return result;
         }
@@ -63,14 +88,6 @@ namespace Wootrade
             return result;
         }
 
-        public async Task<WebCallResult<WootradeOrderInfo>> GetOrderAsync(int clientOrderId)
-        {
-            var result = await this.SendRequestInternal<WootradeOrderInfo>(this.GetUri("client/order", false, clientOrderId.ToString()), HttpMethod.Get, CancellationToken.None, null, true);
-
-            return new WebCallResult<WootradeOrderInfo>(result.ResponseStatusCode,
-                result.ResponseHeaders, result.Data, result.Error);
-        }
-
         public async Task<WebCallResult<WootradeOrderBook>> GetOrderBookAsync(string symbol)
         {
             var result = await this.SendRequestInternal<WootradeOrderBook>(this.GetUri("orderbook", false, symbol), HttpMethod.Get, CancellationToken.None, null, true);
@@ -79,6 +96,22 @@ namespace Wootrade
                 result.Data.Symbol = symbol;
 
             return new WebCallResult<WootradeOrderBook>(result.ResponseStatusCode,
+                result.ResponseHeaders, result.Data, result.Error);
+        }
+
+        public async Task<WebCallResult<WootradeOrderInfo>> GetOrderByClientOrderIdAsync(int clientOrderId)
+        {
+            var result = await this.SendRequestInternal<WootradeOrderInfo>(this.GetUri("client/order", false, clientOrderId.ToString()), HttpMethod.Get, CancellationToken.None, null, true);
+
+            return new WebCallResult<WootradeOrderInfo>(result.ResponseStatusCode,
+                result.ResponseHeaders, result.Data, result.Error);
+        }
+
+        public async Task<WebCallResult<WootradeOrderInfo>> GetOrderByWootradeOrderIdAsync(int orderId)
+        {
+            var result = await this.SendRequestInternal<WootradeOrderInfo>(this.GetUri("order", false, orderId.ToString()), HttpMethod.Get, CancellationToken.None, null, true);
+
+            return new WebCallResult<WootradeOrderInfo>(result.ResponseStatusCode,
                 result.ResponseHeaders, result.Data, result.Error);
         }
 


### PR DESCRIPTION
This PR implements the following endpoints:
- SendOrder (PlaceOrder)
- CancelOrder by ClientOrderId
- CancelOrder by OrderId
- CancelOrder by Symbol
- GetCurrentHoldings (v2)
- GetOrder by ClientOrderId
- GetOrder by OrderId

About the Cancel Order endpoints, a bug to Wootrade has been reported. Check the status here:
https://github.com/rodrigobelo/wootrade-dotnet/blob/main/WOOTRADE_ISSUES.md